### PR TITLE
Remove need to pass in 'game' enum when packing LZ file.

### DIFF
--- a/GxUtils/LibGxFormat/GxGame.cs
+++ b/GxUtils/LibGxFormat/GxGame.cs
@@ -17,7 +17,10 @@ namespace LibGxFormat
         SuperMonkeyBallDX,
         /// <summary>F-Zero GX</summary>
         [Description("F-Zero GX")]
-        FZeroGX
+        FZeroGX,
+        /// <summary>F-Zero AX</summary>
+        [Description("F-Zero AX")]
+        FZeroAX,
     }
 }
 


### PR DESCRIPTION
* Add FZeroAX enum to GxGame. F-Zero AX and GX share the same structure formats for both TPL and GMA.
* Remove need to pass 'game' enum when for Pack method. When packing LZ file, deduce compatibility from headerFieldSize and actual file size.
* Add switch case to Unpack method, check when for game enum and subtract when appropriate. This makes it more clear what is going on and will throw an error if another game is added to the GxGame enum, forcing it to be handled correctly.